### PR TITLE
Add new RHS size function

### DIFF
--- a/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Size.java
+++ b/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Size.java
@@ -1,0 +1,30 @@
+package org.jsoar.kernel.rhs.functions;
+
+import java.util.List;
+
+import org.jsoar.kernel.symbols.Identifier;
+import org.jsoar.kernel.symbols.Symbol;
+
+import com.google.common.collect.Streams;
+
+public class Size extends AbstractRhsFunctionHandler {
+
+    public Size() {
+        super("size", 1, 1);
+    }
+
+    @Override
+    public Symbol execute(RhsFunctionContext context, List<Symbol> arguments) throws RhsFunctionException {
+        RhsFunctions.checkArgumentCount(this, arguments);
+
+        Identifier sizeId = arguments.get(0).asIdentifier();
+        if (sizeId == null) {
+            throw new RhsFunctionException(this.getName() + " was called with a non-identifer argument in rule "
+                    + context.getProductionBeingFired());
+        }
+
+        long sizeCount = Streams.stream(sizeId.getWmes()).count();
+        return context.getSymbols().createInteger(sizeCount);
+    }
+
+}

--- a/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Size.java
+++ b/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Size.java
@@ -7,18 +7,22 @@ import org.jsoar.kernel.symbols.Symbol;
 
 import com.google.common.collect.Streams;
 
-public class Size extends AbstractRhsFunctionHandler {
+public class Size extends AbstractRhsFunctionHandler 
+{
 
-    public Size() {
+    public Size() 
+    {
         super("size", 1, 1);
     }
 
     @Override
-    public Symbol execute(RhsFunctionContext context, List<Symbol> arguments) throws RhsFunctionException {
+    public Symbol execute(RhsFunctionContext context, List<Symbol> arguments) throws RhsFunctionException 
+    {
         RhsFunctions.checkArgumentCount(this, arguments);
 
         Identifier sizeId = arguments.get(0).asIdentifier();
-        if (sizeId == null) {
+        if (sizeId == null) 
+        {
             throw new RhsFunctionException(this.getName() + " was called with a non-identifer argument in rule "
                     + context.getProductionBeingFired());
         }

--- a/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/StandardFunctions.java
+++ b/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/StandardFunctions.java
@@ -107,7 +107,8 @@ public class StandardFunctions
             new ListRhsFunction(),
             new FormatRhsFunction(),
             new Timestamp(),
-            new SetCount()));
+            new SetCount(), 
+            new Size()));
     {
         allInternal.addAll(MathFunctions.ALL);
     }

--- a/jsoar-core/src/test/java/org/jsoar/kernel/rhs/functions/SizeTest.java
+++ b/jsoar-core/src/test/java/org/jsoar/kernel/rhs/functions/SizeTest.java
@@ -1,0 +1,175 @@
+package org.jsoar.kernel.rhs.functions;
+
+import org.jsoar.JSoarTest;
+import org.jsoar.kernel.Agent;
+import org.jsoar.kernel.RunType;
+import org.jsoar.kernel.SoarProperties;
+import org.jsoar.kernel.symbols.Symbol;
+import org.jsoar.util.ByRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import java.util.List;
+
+public class SizeTest extends JSoarTest 
+{
+    private Agent agent;
+    ByRef<Boolean> matched;
+
+    @BeforeEach
+    void initAgent() throws Exception 
+    {
+        this.agent = new Agent();
+        this.matched = ByRef.create(Boolean.FALSE);
+        agent.getRhsFunctions().registerHandler(new StandaloneRhsFunctionHandler("match") {
+
+            @Override
+            public Symbol execute(RhsFunctionContext context, List<Symbol> arguments) throws RhsFunctionException {
+                matched.value = true;
+                return null;
+            }
+        });
+
+    }
+
+    @Test
+    void TestNoArgs() throws Exception 
+    {
+        // A production to call set-count with bad args
+        agent.getProductions().loadProduction("" +
+                "countSize\n" +
+                "(state <s> ^superstate nil )\n" +
+                "-->\n" +
+                "(<s> ^count-size (size))");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        StringWriter sw = new StringWriter();
+        agent.getPrinter().pushWriter(sw);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(sw.toString().contains("Error executing RHS function"));
+    }
+
+    @Test
+    void TestTwoArgs() throws Exception 
+    {
+        // A production to create ^to-count & ^to-count2
+        agent.getProductions().loadProduction("" +
+                "createSizeTest\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^to-count <tc> ^to-count2 <tc2>) " +
+                "(<tc> ^foo one)" +
+                "(<tc2> ^foo2 one)");
+
+        // A production to count ^to-count with size function
+        agent.getProductions().loadProduction("" +
+                "countSize\n" +
+                "(state <s> ^superstate nil ^to-count <tc> ^to-count2 <tc2>)\n" +
+                "-->\n" +
+                "(<s> ^count (size <tc> <tc2>))");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        StringWriter sw = new StringWriter();
+        agent.getPrinter().pushWriter(sw);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(sw.toString().contains("Error executing RHS function"));
+    }
+
+    @Test
+    void TestOneArgsCountOne() throws Exception 
+    {
+        // A production to create ^to-count with one WME
+        agent.getProductions().loadProduction("" +
+                "createSizeTest\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^to-count <tc>)" +
+                "(<tc> ^foo one)");
+
+        // A production to count ^to-count with size function
+        agent.getProductions().loadProduction("" +
+                "countSize\n" +
+                "(state <s> ^superstate nil ^to-count <tc>)\n" +
+                "-->\n" +
+                "(<s> ^count (size <tc>))");
+
+        // Finally a production to validate that the size count is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^count 1)\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void TestOneArgsCountTwo() throws Exception 
+    {
+        // A production to create ^to-count with two WMEs
+        agent.getProductions().loadProduction("" +
+                "createSizeTest\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^to-count <tc>)" +
+                "(<tc> ^foo one ^bar two)");
+
+        // A production to count ^to-count with size function
+        agent.getProductions().loadProduction("" +
+                "countSize\n" +
+                "(state <s> ^superstate nil ^to-count <tc>)\n" +
+                "-->\n" +
+                "(<s> ^count (size <tc>))");
+
+        // Finally a production to validate that the size count is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^count 2)\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void TestOneArgsCountThree() throws Exception 
+    {
+        // A production to create ^to-count with three WMEs
+        agent.getProductions().loadProduction("" +
+                "createSizeTest\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^to-count <tc>)" +
+                "(<tc> ^foo one ^bar two ^foo three)");
+
+        // A production to count ^to-count with size function
+        agent.getProductions().loadProduction("" +
+                "countSize\n" +
+                "(state <s> ^superstate nil ^to-count <tc>)\n" +
+                "-->\n" +
+                "(<s> ^count (size <tc>))");
+
+        // Finally a production to validate that the size count is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^count 3)\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+}


### PR DESCRIPTION
This Pull Request proposes the addition of a new RHS "size" function. The new function is based on the description provided in the Soar Manual documentation (3.3.6.6 Right-hand side Functions, page 79), and is designed to return an integer value representing the count of WME augmentations on a given ID argument. However as stated, it is important to note that providing a non-ID argument to the function will result in an error, indicating that the function is intended to be used specifically for counting WME augmentations on ID arguments.

The jsoar version of the codebase currently does not have this function implemented, and the proposed function will be a valuable addition to the codebase. It will provide developers with an easy and efficient way to count WME augmentations on ID arguments. The changes are backward-compatible and have no impact on the existing functionality of the codebase.

The proposed changes have been tested, and a test file has been included to verify the correct implementation of the new RHS size function.