### PR TITLE
Add new RHS trim function

### DIFF
--- a/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/StandardFunctions.java
+++ b/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/StandardFunctions.java
@@ -108,7 +108,8 @@ public class StandardFunctions
             new FormatRhsFunction(),
             new Timestamp(),
             new SetCount(), 
-            new Size()));
+            new Size(),
+            new Trim()));
     {
         allInternal.addAll(MathFunctions.ALL);
     }

--- a/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Trim.java
+++ b/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Trim.java
@@ -24,7 +24,7 @@ public class Trim extends AbstractRhsFunctionHandler
                     + context.getProductionBeingFired());
         }
         
-        return context.getSymbols().createString(strArg.toString().trim());
+        return context.getSymbols().createString(strArg.toString().strip());
     }
 
 }

--- a/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Trim.java
+++ b/jsoar-core/src/main/java/org/jsoar/kernel/rhs/functions/Trim.java
@@ -1,0 +1,30 @@
+package org.jsoar.kernel.rhs.functions;
+
+import java.util.List;
+import org.jsoar.kernel.symbols.StringSymbol;
+import org.jsoar.kernel.symbols.Symbol;
+
+public class Trim extends AbstractRhsFunctionHandler 
+{
+
+    public Trim() 
+    {
+        super("trim", 1, 1);
+    }
+
+    @Override
+    public Symbol execute(RhsFunctionContext context, List<Symbol> arguments) throws RhsFunctionException 
+    {
+        RhsFunctions.checkArgumentCount(this, arguments);
+        
+        StringSymbol strArg = arguments.get(0).asString();
+        if (strArg == null) 
+        {
+            throw new RhsFunctionException(this.getName() + " was called with a non-string symbol argument in rule "
+                    + context.getProductionBeingFired());
+        }
+        
+        return context.getSymbols().createString(strArg.toString().trim());
+    }
+
+}

--- a/jsoar-core/src/test/java/org/jsoar/kernel/rhs/functions/TrimTest.java
+++ b/jsoar-core/src/test/java/org/jsoar/kernel/rhs/functions/TrimTest.java
@@ -1,0 +1,247 @@
+package org.jsoar.kernel.rhs.functions;
+
+import org.jsoar.JSoarTest;
+import org.jsoar.kernel.Agent;
+import org.jsoar.kernel.RunType;
+import org.jsoar.kernel.SoarProperties;
+import org.jsoar.kernel.symbols.Symbol;
+import org.jsoar.util.ByRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import java.util.List;
+
+public class TrimTest extends JSoarTest {
+    private Agent agent;
+    ByRef<Boolean> matched;
+
+    @BeforeEach
+    void initAgent() throws Exception {
+        this.agent = new Agent();
+        this.matched = ByRef.create(Boolean.FALSE);
+        agent.getRhsFunctions().registerHandler(new StandaloneRhsFunctionHandler("match") {
+
+            @Override
+            public Symbol execute(RhsFunctionContext context, List<Symbol> arguments) throws RhsFunctionException {
+                matched.value = true;
+                return null;
+            }
+        });
+
+    }
+
+    @Test
+    void testNoArgs() throws Exception {
+        // A production to call trim with bad args
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim))");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        StringWriter sw = new StringWriter();
+        agent.getPrinter().pushWriter(sw);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(sw.toString().contains("Error executing RHS function"));
+    }
+
+    @Test
+    void testTwoArgs() throws Exception {
+        // A production to create ^message & ^message2
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |message| ^message2 |message2|)");
+
+        // A production to trim with two args which leads to an error
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> ^message2 <m2>)\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> <m2>))");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        StringWriter sw = new StringWriter();
+        agent.getPrinter().pushWriter(sw);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(sw.toString().contains("Error executing RHS function"));
+    }
+
+    @Test
+    void testWithLeadingWhiteSpace() throws Exception {
+        // A production to create ^message with leading white space
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message | this is a test message| )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithMultipleLeadingWhiteSpaces() throws Exception {
+        // A production to create ^message with multiple leading white spaces
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |     this is a test message| )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithTrailingWhiteSpace() throws Exception {
+        // A production to create ^message with trailing white space
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |this is a test message | )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithMultipleTrailingWhiteSpaces() throws Exception {
+        // A production to create ^message with multiple trailing white spaces
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |this is a test message    | )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithNoLeadingAndTrailingWhiteSpaces() throws Exception {
+        // A production to create ^message with no leading or trailing white spaces
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |this is a test message| )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithNonStringSymbol() throws Exception {
+
+        // A production to create a non string symbol
+        agent.getProductions().loadProduction("" +
+                "createNonString\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^foobars <fbs>)" +
+                "(<fbs> ^foo one ^bar two)");
+
+        // A production to trim the ^foobars
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^foobars <fbs> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <fbs> ))");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        StringWriter sw = new StringWriter();
+        agent.getPrinter().pushWriter(sw);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(sw.toString().contains("Error executing RHS function"));
+    }
+
+}

--- a/jsoar-core/src/test/java/org/jsoar/kernel/rhs/functions/TrimTest.java
+++ b/jsoar-core/src/test/java/org/jsoar/kernel/rhs/functions/TrimTest.java
@@ -244,4 +244,148 @@ public class TrimTest extends JSoarTest {
         assertTrue(sw.toString().contains("Error executing RHS function"));
     }
 
+    @Test
+    void testWithMultipleLeadingUnicodes() throws Exception {
+        // A production to create ^message with multiple leading unicodes
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message | \n \u2000 this is a test message| )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithMultipleTrailingUnicodes() throws Exception {
+        // A production to create ^message with multiple trailing unicodes
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message | this is a test message \n \u2000 | )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithLeadingAndTrailingUnicodesAndWhiteSpaces() throws Exception {
+        // A production to create ^message with multiple leading and trailing unicodes and whitespaces
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message | \n \t \u2000  this is a test message  \n \t \u2000  | )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithMultipleMiddleUnicodes() throws Exception {
+        // A production to create ^message with multiple middle unicodes
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |this\u0020is a test\u0020message| )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
+
+    @Test
+    void testWithLeadingTrailingMiddleUnicodesAndWhiteSpaces() throws Exception {
+        // A production to create ^message with multiple leading, trailing and middle unicodes and whitespaces
+        agent.getProductions().loadProduction("" +
+                "createMessages\n" +
+                "(state <s> ^superstate nil)\n" +
+                "-->\n" +
+                "(<s> ^message |  \u2000 \n \u0020 this\u0020is a test\u0020message \u2000 \u0020 \t  | )");
+
+        // A production to trim the ^message
+        agent.getProductions().loadProduction("" +
+                "trimMessage\n" +
+                "(state <s> ^superstate nil ^message <m1> )\n" +
+                "-->\n" +
+                "(<s> ^trimmed (trim <m1> ))");
+
+        // Finally a production to validate that the trim function is correct
+        agent.getProductions().loadProduction("" +
+                "testStructure\n" +
+                "(state <s> ^trimmed |this is a test message| )\n" +
+                "-->\n" +
+                "(match)");
+
+        agent.getProperties().set(SoarProperties.WAITSNC, true);
+        agent.runFor(2, RunType.DECISIONS);
+
+        assertTrue(matched.value);
+    }
 }


### PR DESCRIPTION
This Pull Request introduces a new RHS "trim" function that takes a single string symbol argument and returns the same string with leading and trailing whitespace removed. 

Similar to PR #137 , this function is based on the specifications outlined in the Soar Manual documentation (3.3.6.6 Right-hand side Functions, page 80). The proposed changes have undergone testing, and a test file has been included to ensure the accurate implementation of the new RHS trim function.